### PR TITLE
Updated capturePage to use NativeImage.toPNG

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -315,7 +315,7 @@ Api.prototype.addCapturePageSupport = function () {
       if (rect != null) args.push(rect)
       args.push(function (image) {
         if (image != null) {
-          done(image.toPng().toString('base64'))
+          done(image.toPNG().toString('base64'))
         } else {
           done(image)
         }


### PR DESCRIPTION
Electron deprecated `toPng` in version X, and replaced it with `toPNG`.
The deprecated `toPng` was removed in version 2.0.0, so `capturePage` is currently broken.